### PR TITLE
Ensure server sends response with status 200

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ node_js:
 
 before_script:
   - npm install
-script: npm test
+script: cp ./example.env ./.env && npm test

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "body-parser": "^1.13.3",
     "dotenv": "^1.2.0",
     "express": "^4.13.3",
-    "node-cache": "^3.0.0",
     "node-slack": "0.0.7",
     "nodeunit": "^0.9.1"
   },

--- a/server.js
+++ b/server.js
@@ -15,10 +15,6 @@ var filter = require('./libs/filter');
 
 var jsonParser = bodyParser.json({type: 'application/*'});
 
-// TODO: Implement Caching to only submit 1 update or find better method
-var nodeCache = require('node-cache');
-var entryCache = new nodeCache({checkperiod: 0});
-
 app.post('/', jsonParser, function (req, res) {
     // if request doesn't contain body, respond with 400 error.
     if (!req.body) {
@@ -31,15 +27,11 @@ app.post('/', jsonParser, function (req, res) {
     if (req.rawHeaders.indexOf('ContentManagement.Entry.publish') > -1 ||
             req.rawHeaders.indexOf('ContentManagement.Asset.publish') > -1 &&
             correctEntry) {
-        var key = req.body.sys.id;
-
-        if (entryCache.get(key) !== true) {
-            var message = messageCtrl.buildMessage(req.body);
-            slackService.sendMessage(message);
-            // Store Entries in ID-Revison#: true -- for 10 Minutes
-            entryCache.set(key, true, 600);
-        }
+        var message = messageCtrl.buildMessage(req.body);
+        slackService.sendMessage(message);
     }
+
+    res.sendStatus(200);
 });
 
 app.get('/check', function (req, res) {


### PR DESCRIPTION
Fixes https://github.com/brh55/slack-contentful/issues/2

Makes sure that contentful does not treat this as a failed delivery and does not try to redeliver the message later.
This makes the caching obsolete.

I haven't actually manually tested this, so maybe just to be sure you can verify that this works.
